### PR TITLE
Fix helpers when it's an object

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -131,9 +131,9 @@ module.exports = (reporter, definition) => {
     if (req.template.helpers && typeof req.template.helpers === 'object') {
       req.template.helpers.pdfCreatePagesGroup = pdfCreatePagesGroup
       req.template.helpers.pdfAddPageItem = pdfAddPageItem
+    } else {
+      req.template.helpers = pdfCreatePagesGroup + '\n' + pdfAddPageItem + '\n' + (req.template.helpers || '')
     }
-
-    req.template.helpers = pdfCreatePagesGroup + '\n' + pdfAddPageItem + '\n' + (req.template.helpers || '')
   })
 
   // we insert to the front so we can run before reports or scripts

--- a/test/test.js
+++ b/test/test.js
@@ -206,6 +206,35 @@ describe('pdf utils', () => {
     parsedPdf.pages[0].text.includes('number').should.be.ok()
   })
 
+  it('should work with helpers in an object', async () => {
+    await jsreport.documentStore.collection('templates').insert({
+      content: '{{test 1}}',
+      shortid: 'header',
+      name: 'header',
+      engine: 'handlebars',
+      recipe: 'chrome-pdf',
+      helpers: {
+        test: v => typeof v
+      }
+    })
+
+    const result = await jsreport.render({
+      template: {
+        content: `{{{pdfCreatePagesGroup num}}}`,
+        engine: 'handlebars',
+        name: 'content',
+        recipe: 'chrome-pdf',
+        pdfOperations: [{ type: 'merge', renderForEveryPage: true, templateShortid: 'header' }]
+      },
+      data: {
+        num: 1
+      }
+    })
+
+    const parsedPdf = await parsePdf(result.content, true)
+    parsedPdf.pages[0].text.includes('number').should.be.ok()
+  })
+
   it('merge with renderForEveryPage should be able to use pdfCreatePagesGroup helper with hash params with jsrender', async () => {
     await jsreport.documentStore.collection('templates').insert({
       content: '{{:$pdf.pages[$pdf.pageIndex].group.foo}}',


### PR DESCRIPTION
There was a check to see if the helpers are an object but after the if-case it was always overwritten to a string. This broke our other helpers.