### PR TITLE
Add Basic Signature Acrofield Support

### DIFF
--- a/lib/utils/formsProcessor.js
+++ b/lib/utils/formsProcessor.js
@@ -181,6 +181,7 @@ function processTextAlign (formSpec, annotation) {
 function processType (formSpec, annotation) {
   switch (formSpec.type) {
     case 'text': return processTextType(formSpec, annotation)
+    case 'signature': return processSignatureType(formSpec, annotation)
     case 'button': return processButtonType(formSpec, annotation)
     case 'combo': return processComboType(formSpec, annotation)
     default: throw new Error(`Unsupported pdfFormElement type ${formSpec.type}`)
@@ -189,6 +190,10 @@ function processType (formSpec, annotation) {
 
 function processTextType (formSpec, annotation) {
   annotation.prop('FT', 'Tx')
+}
+
+function processSignatureType (formSpec, annotation) {
+  annotation.prop('FT', 'Sig')
 }
 
 function processComboType (formSpec, annotation) {

--- a/test/test.js
+++ b/test/test.js
@@ -1563,6 +1563,25 @@ describe('pdf utils', () => {
     field.properties.get('AA').get('F').get('JS').toString().should.be.eql('(AFNumber_Format\\(2,0,"ParensRed",null,"$",true\\);)')
   })
 
+  it('pdfFormField with signature type', async () => {
+    const result = await jsreport.render({
+      template: {
+        recipe: 'chrome-pdf',
+        engine: 'handlebars',
+        content: `{{{pdfFormField name='test' type='signature' width='100px' height='50px'}}}`
+      }
+    })
+
+    const doc = new pdfjs.ExternalDocument(result.content)
+
+    const acroForm = doc.catalog.get('AcroForm').object
+    const field = acroForm.properties.get('Fields')[0].object
+
+    field.properties.get('FT').toString().should.be.eql('/Sig')
+    
+
+  })
+
   it('pdfFormField with combo type', async () => {
     const result = await jsreport.render({
       template: {


### PR DESCRIPTION
As per issue [https://github.com/jsreport/jsreport/issues/754](https://github.com/jsreport/jsreport/issues/754), we added a very basic support for Acrofield Signature type.